### PR TITLE
Remove document.clear(), it's deprecated.

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,6 @@ var Frame = React.createClass({
 
       var initialRender = !this._setInitialContent;
       if (!this._setInitialContent) {
-        doc.clear();
         doc.open();
         doc.write(this.props.initialContent);
         doc.close();


### PR DESCRIPTION
`document.clear` [is deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Document/clear). It's also unneccessary, since `document.open` [also clears the document](https://developer.mozilla.org/en-US/docs/Web/API/Document/open)
